### PR TITLE
adding OHLOOM manifest link

### DIFF
--- a/projects_okhs.csv
+++ b/projects_okhs.csv
@@ -17,3 +17,4 @@ NYC-MTA-Next-Train, 2019-11-16, https://raw.githubusercontent.com/mwweinberg/NYC
 ZACplus, 2019-11-15, https://raw.githubusercontent.com/case06/ZACplus/master/okh-ZACplus.yml
 OpenFlexure Microscope, 2020-02-13, https://gitlab.com/openflexure/openflexure-microscope/-/raw/master/okh.yml
 OpenFlexure Block Stage, 2020-02-13, https://gitlab.com/openflexure/openflexure-block-stage/-/raw/master/okh-openflexure-block-stage.yml
+OHLOOM (Open Hardware Webstuhl), 2020-02-23, https://gitlab.com/BBScar/OHLOOM/-/raw/master/okh.yml


### PR DESCRIPTION
will be available tomorrow (monday 24. Feb. 2020), most likely