### PR TITLE
Updated braille generator link and added push button switch link

### DIFF
--- a/okh-config.json
+++ b/okh-config.json
@@ -402,6 +402,7 @@
     "https://openknowhow.appropedia.org/manifests/okh-Yamaha%20Quick%20Fastener.yml",
     "https://openknowhow.appropedia.org/manifests/okh-Zero-electricity%20refrigerator.yml",
     "https://gitlab.com/openflexure/openflexure-simple-illumination/-/raw/master/okh.yml",
-    "https://raw.githubusercontent.com/7B-Things/braille-signage-generator/main/okh.yml"
+    "https://codeberg.org/7BIndustries/braille-label-generator/raw/branch/main/okh.yml",
+    "https://codeberg.org/7BIndustries/push-button-switch/raw/branch/main/okh.yml"
   ]
 }


### PR DESCRIPTION
Both of these projects have been migrated to Codeberg. The GitHub repos have been archived with a note at the top of the readmes. The braille generator link is being updated, and the switch link is being added for the first time.

* [Braille Generator](https://github.com/7B-Things/braille-signage-generator)
* [Push Button Switch](https://github.com/7B-Things/push-button-switch)